### PR TITLE
[FIX] token amount now is bytes, not int64

### DIFF
--- a/src/Hydra/ContractInput.cpp
+++ b/src/Hydra/ContractInput.cpp
@@ -2,9 +2,10 @@
 
 #include "ContractInput.h"
 
-TW::Hydra::ContractInput::ContractInput(const Proto::ContractInput& input){
+TW::Hydra::ContractInput::ContractInput(const Proto::ContractInput& input)
+{
     gasLimit = input.gas_limit();
     gasPrice = input.gas_price();
     to = input.to();
-    amount = input.amount();
+    amount = Data(input.amount().begin(), input.amount().end());
 }

--- a/src/Hydra/ContractInput.h
+++ b/src/Hydra/ContractInput.h
@@ -8,6 +8,7 @@
 
 #include<string>
 #include "../Bitcoin/Amount.h"
+#include "../Data.h"
 #include "../proto/Hydra.pb.h"
 
 namespace TW::Hydra{
@@ -20,7 +21,7 @@ public:
 
     std::string to;
     
-    TW::Bitcoin::Amount amount;
+    Data amount;
 
     ContractInput() = default;
 

--- a/src/Hydra/TokenScript.cpp
+++ b/src/Hydra/TokenScript.cpp
@@ -84,7 +84,7 @@ void insert(Data& script, Data& input){
     append(script, input);
 }
 
-Bitcoin::Script Hydra::TokenScript::buildTokenScript(int64_t gasLimit, const std::string& to, uint64_t amount, const std::string& contractAddress){
+Bitcoin::Script Hydra::TokenScript::buildTokenScript(int64_t gasLimit, const std::string& to, Data& amount, const std::string& contractAddress){
     
     //Build the transaction
     Data script;
@@ -95,12 +95,13 @@ Bitcoin::Script Hydra::TokenScript::buildTokenScript(int64_t gasLimit, const std
     //Convert the gas limit to hex
     Data gasLimitData = numberToBuffer(gasLimit);
 
-
     //Insert the gas limit data
     insert(script, gasLimitData);
 
+    uint256_t amountNumbered = load(amount);
+
     // Building the transfer function
-    Data data = Ethereum::TransactionNonTyped::buildERC20TransferCall(AnyAddress::dataFromString(to,TWCoinTypeHydra), amount);
+    Data data = Ethereum::TransactionNonTyped::buildERC20TransferCall(AnyAddress::dataFromString(to,TWCoinTypeHydra), amountNumbered);
 
     //Insert the encoded data
     insert(script, data);

--- a/src/Hydra/TokenScript.h
+++ b/src/Hydra/TokenScript.h
@@ -16,7 +16,7 @@ namespace TW::Hydra{
 
 class TokenScript{
 public:
-    static TW::Bitcoin::Script buildTokenScript(int64_t gasLimit, const std::string& to, uint64_t amount, const std::string& contractAddress);
+    static TW::Bitcoin::Script buildTokenScript(int64_t gasLimit, const std::string& to, Data& amount, const std::string& contractAddress);
 
     static TW::Bitcoin::Script buildContractCallScript(int64_t gasLimit, const std::string& function, std::vector<ContractCallParam>& params, const std::string contractAddress);
 };

--- a/src/proto/Hydra.proto
+++ b/src/proto/Hydra.proto
@@ -19,7 +19,7 @@ message ContractInput {
     string to = 3;
 
     // Transaction amount.
-    int64 amount = 4;
+    bytes amount = 4;
 }
 
 message ContractCallParam{

--- a/tests/Hydra/ComparisonHelper.cpp
+++ b/tests/Hydra/ComparisonHelper.cpp
@@ -21,7 +21,7 @@
 
 
 
-Bitcoin::Script buildTokenScript(int32_t gasLimit, std::string toAddress, uint32_t amount, std::string contractAddress){
+Bitcoin::Script buildTokenScript(int32_t gasLimit, std::string toAddress, Data amount, std::string contractAddress){
     return Hydra::TokenScript::buildTokenScript(gasLimit, toAddress, amount, contractAddress);
 }
 
@@ -68,7 +68,7 @@ Hydra::ContractInput  buildHydraContractInput(Bitcoin::Amount gasLimit, Bitcoin:
     input.gasLimit = gasLimit;
     input.gasPrice = gasPrice;
     input.to = to;
-    input.amount = amount;
+    input.amount = store(amount);
 
     return input;
 }

--- a/tests/Hydra/ComparisonHelper.h
+++ b/tests/Hydra/ComparisonHelper.h
@@ -17,7 +17,7 @@
 
 using namespace TW;
 
-Bitcoin::Script buildTokenScript(int32_t gasLimit, std::string toAddress, uint32_t amount, std::string contractAddress);
+Bitcoin::Script buildTokenScript(int32_t gasLimit, std::string toAddress, Data amount, std::string contractAddress);
 
 /// Build a dummy UTXO with the given amount
 Bitcoin::UTXO buildTestHydraUTXO(int64_t amount);


### PR DESCRIPTION
Fixed int64 overflowing when parsing the amount of tokens to transfer.
