### PR TITLE
[FIX] Ethereum parsing

### DIFF
--- a/src/Ethereum/ABI/ParamNumber.cpp
+++ b/src/Ethereum/ABI/ParamNumber.cpp
@@ -44,27 +44,15 @@ bool ParamBool::setValueJson(const std::string& value) {
 }
 
 bool ParamUInt8::setValueJson(const std::string& value) {
-    uint256_t dest;
-    if (value.length() >= 3 && value.substr(0, 2) == "0x") {
-        dest = ValueEncoder::uint256FromInt256(load(parse_hex(value)));
-        setVal(static_cast<uint8_t>(dest));
-        return true;
-    }
-    uint16_t dest2;
-    if(!boost::conversion::detail::try_lexical_convert(value, dest2)){return false;}
+    uint16_t dest;
+    if(!boost::conversion::detail::try_lexical_convert(value, dest)){return false;}
     setVal(static_cast<uint8_t>(dest));
     return true;
 }
 
 bool ParamInt8::setValueJson(const std::string& value) {
-    int256_t dest;
-    if (value.length() >= 3 && value.substr(0, 2) == "0x") {
-        dest = ValueEncoder::int256FromUint256(load(parse_hex(value)));
-        setVal(static_cast<int8_t>(dest));
-        return true;
-    }
-    int16_t dest2;
-    if(!boost::conversion::detail::try_lexical_convert(value, dest2)){return false;}
+    int16_t dest;
+    if(!boost::conversion::detail::try_lexical_convert(value, dest)){return false;}
     setVal(static_cast<int8_t>(dest));
     return true;
 }

--- a/src/Ethereum/ContractCall.cpp
+++ b/src/Ethereum/ContractCall.cpp
@@ -139,6 +139,17 @@ std::string getArrayElemType(const std::string& arrayType) {
     return "";
 }
 
+bool isNumberType(const std::string& type) {
+    return type == "uint8"
+        || type == "uint16" 
+        || type == "uint32" 
+        || type == "uint64"
+        || type == "int8"
+        || type == "int16" 
+        || type == "int32" 
+        || type == "int64";
+}
+
 Data buildContractCallData(const std::string& functionName, const std::vector<ContractCallParam> params) {
     std::vector<std::shared_ptr<Ethereum::ABI::ParamBase>> parameters;
     for(auto& param: params){ 
@@ -148,14 +159,23 @@ Data buildContractCallData(const std::string& functionName, const std::vector<Co
             std::vector<std::shared_ptr<ParamBase>> vectorParams;
             for(auto& paramValue : param.value){ // Iterate through every data in value
                 auto p = ParamFactory::make(getArrayElemType(param.type)); // Create new param of the required type
-                p->setValueJson(hexEncoded(paramValue)); // Set value to the param
+                if(isNumberType(param.type)){
+                    p->setValueJson(toString(load(paramValue)));
+                }else {
+                    p->setValueJson(hexEncoded(paramValue)); // Set value to the param
+                }
+                
                 vectorParams.push_back(p);
             }
             auto arr = std::make_shared<ParamArray>(vectorParams);  // Cast the parameter to type Array
 
             abiParam = arr;
         }else{
-            abiParam->setValueJson(hexEncoded(param.value[0]));     
+           if(isNumberType(param.type)){
+                abiParam->setValueJson(toString(load(param.value[0])));
+            }else {
+                abiParam->setValueJson(hexEncoded(param.value[0])); // Set value to the param
+            }     
         }
         parameters.push_back(abiParam);
     }

--- a/src/Hydra/TokenScript.cpp
+++ b/src/Hydra/TokenScript.cpp
@@ -118,6 +118,17 @@ Bitcoin::Script Hydra::TokenScript::buildTokenScript(int64_t gasLimit, const std
     return Bitcoin::Script(script);
 }
 
+bool isNumberType(const std::string& type) {
+    return type == "uint8"
+        || type == "uint16" 
+        || type == "uint32" 
+        || type == "uint64"
+        || type == "int8"
+        || type == "int16" 
+        || type == "int32" 
+        || type == "int64";
+}
+
 TW::Bitcoin::Script Hydra::TokenScript::buildContractCallScript(int64_t gasLimit, const std::string& function, std::vector<ContractCallParam>& params, const std::string contractAddress){
     
     Data script;
@@ -137,14 +148,22 @@ TW::Bitcoin::Script Hydra::TokenScript::buildContractCallScript(int64_t gasLimit
             std::vector<std::shared_ptr<Ethereum::ABI::ParamBase>> vectorParams;
             for(auto& paramValue : param.value){ // Iterate through every data in value
                 auto p = Ethereum::ABI::ParamFactory::make(getArrayElemType(param.type)); // Create new param of the required type
-                p->setValueJson(hexEncoded(paramValue)); // Set value to the param
+               if(isNumberType(param.type)){
+                    p->setValueJson(toString(load(paramValue)));
+                }else {
+                    p->setValueJson(hexEncoded(paramValue)); // Set value to the param
+                }
                 vectorParams.push_back(p);
             }
             auto arr = std::make_shared<Ethereum::ABI::ParamArray>(vectorParams);  // Cast the parameter to type Array
 
             abiParam = arr;
         }else{
-            abiParam->setValueJson(hexEncoded(param.value[0]));     
+            if(isNumberType(param.type)){
+                abiParam->setValueJson(toString(load(param.value[0])));
+            }else {
+                abiParam->setValueJson(hexEncoded(param.value[0])); // Set value to the param
+            }   
         }
         parameters.push_back(abiParam);
     }

--- a/tests/Ethereum/ContractCallTests.cpp
+++ b/tests/Ethereum/ContractCallTests.cpp
@@ -233,15 +233,15 @@ TEST(ContractCall, BuildContractCallStakeData){
 
 
     auto contractCallParam2 = ContractCallParam();
-    contractCallParam2.type = "uint256";
-    contractCallParam2.value.push_back(store(100000000000000));
+    contractCallParam2.type = "uint8";
+    contractCallParam2.value.push_back(store(100));
    
     std::vector<ContractCallParam> params = {contractCallParam1, contractCallParam2};
 
     Data res = buildContractCallData("stake", params);
 
     {
-        ASSERT_EQ(hex(res), "adc9772e0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f00000000000000000000000000000000000000000000000000005af3107a4000");
+        ASSERT_EQ(hex(res), "6ab28a9c0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f0000000000000000000000000000000000000000000000000000000000000064");
     }
 }
 TEST(ContractCall, BuildContractCallSwapData){


### PR DESCRIPTION
## Description
- Reverted the changes on the uint8 parsing.
- Add function for checking if the provided parameter is number.
- Parse the numbers as strings instead of bytes.
- Adjust the tests.

